### PR TITLE
Allow D files in the global `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Prerequisites
-*.d
-
 # Object files
 *.o
 *.ko


### PR DESCRIPTION
The default C `.gitignore` skips `.d` files, but they are required for D demos and exercises.
