### PR TITLE
readme: add details for first time template users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Template Repository
+# OER Template Repository
 
 These are open educational resources ([OER](https://en.wikipedia.org/wiki/Open_educational_resources)).
+The repository should be used as a template for the your own classes.
 
 ## Using the Content
 
@@ -64,3 +65,13 @@ Contributions are welcome.
 See the [contribution guide](CONTRIBUTING.md) on how you could report or fix issues and on how you can improve the content.
 
 Reviewers are requested to follow the [reviewing guide](REVIEWING.md).
+
+## Publishing workflow
+
+Before building the repository you have to setup the following items
+
+* select the GitHub Pages branch by following the [Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) tutorial; you will have to set up the `gh-pages` branch as the publishing branch;
+* add a publishing key named `ACCESS_TOKEN` by following the [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) tutorial.
+
+In order to publish the content of this repository, we use a github workflow located in the `.github/workflows/deployment.yml`.
+This workflow will build the site using docusaurus and publish the contents to a link similar to `<repository_name>.github.io`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Practice content is expected to be used hands-on individually or as part of team
 
 ## Publishing workflow
 
-Before building the repository you have to setup the following items
+Before building the repository you have to set up the following items:
 
 * select the GitHub Pages branch by following the [Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) tutorial; you will have to set up the `gh-pages` branch as the publishing branch;
 * add a publishing key named `ACCESS_TOKEN` by following the [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) tutorial.
@@ -27,7 +27,7 @@ This workflow will build the site using [Docusaurus](https://docusaurus.io/) and
 
 ## Your first TODOs
 
-In order to make this repo your own, for the class that you intend to develop content for you must make the following changes:
+To configure this repo for the class for which you intend to develop content, you must make the following changes:
 
 * change the repository name to match your class name, the default is `oer-template`
 * in `config.yaml`:
@@ -41,16 +41,16 @@ In order to make this repo your own, for the class that you intend to develop co
 When testing locally, you will have to build the container that will run the builder based on the `Dockerfile` defined in the repository root as follows:
 
 ```
-docker build --no-cache -f ./Dockerfile --tag oer-template/docusaurus:latest .
+docker build --no-cache -f ./Dockerfile --tag <your-repo-name>/docusaurus:latest .
 ```
 
 In order to run the builder which will create the repository locally, you will have to run the newly built container:
 
 ```
-docker run -it -v $PWD/:/content -v $PWD/../output:/output oer-template/docusaurus:latest
+docker run -it -v $PWD/:/content -v $PWD/../output:/output <your-repo-name>/docusaurus:latest
 ```
 
-Finally, when wanting to view the content locally you will have to start a container by running the following command:
+Finally, to view the content locally, you will have to start a container by running the following command:
 
 The website will be available by accessing the `http://localhost:3000` address.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To configure this repo for the class for which you intend to develop content, yo
   * change `title` to you class name;
   * change `url` to `<github_usename>.github.io`;
   * change `baseurl` to `/` if the repository is the only one with a GitHub page in your profile, otherwise, change it to `<repository_name>`;
-  * change links to social media sites, if applicable;
+  * change links to social media sites, if applicable.
 
 ## Running locally
 
@@ -56,7 +56,8 @@ Finally, to view the content locally, you will have to start a container by runn
 python3 -m http.server
 ```
 
-The website will be available by accessing the `http://localhost:8000` address. To change the defualt port you will add this a parameter to the above command as follows.
+The website will be available by accessing the `http://localhost:8000` address.
+To change the defualt port you will add this a parameter to the above command as follows.
 
 ```
 python3 -m http.server 8888
@@ -64,7 +65,7 @@ python3 -m http.server 8888
 
 This command will open the web server on port `8888`.
 
-Make sure that you run command in the `output directory`.
+Make sure that you run command in the `output` directory.
 
 
 ## Chapter Contents

--- a/README.md
+++ b/README.md
@@ -15,6 +15,45 @@ Content for each chapter is split in two subfolders:
 Lecture content is expected to be presented and followed.
 Practice content is expected to be used hands-on individually or as part of team.
 
+## Publishing workflow
+
+Before building the repository you have to setup the following items
+
+* select the GitHub Pages branch by following the [Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) tutorial; you will have to set up the `gh-pages` branch as the publishing branch;
+* add a publishing key named `ACCESS_TOKEN` by following the [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) tutorial.
+
+In order to publish the content of this repository, we use a GitHub workflow located in the `.github/workflows/deployment.yml`.
+This workflow will build the site using [Docusaurus](https://docusaurus.io/) and publish the contents to a link similar to `<github_username>.github.io`.
+
+## Your first TODOs
+
+In order to make this repo your own, for the class that you intend to develop content for you must make the following changes:
+
+* change the repository name to match your class name, the default is `oer-template`
+* in `config.yaml`:
+  * change `title` to you class name;
+  * change `url` to `<github_usename>.github.io`;
+  * change `baseurl` to `/` if the repository is the only one with a GitHub page in your profile, otherwise, change it to `<repository_name>`;
+  * change links to social media sites, if applicable;
+
+## Running locally
+
+When testing locally, you will have to build the container that will run the builder based on the `Dockerfile` defined in the repository root as follows:
+
+```
+docker build --no-cache -f ./Dockerfile --tag oer-template/docusaurus:latest .
+```
+
+In order to run the builder which will create the repository locally, you will have to run the newly built container:
+
+```
+docker run -it -v $PWD/:/content -v $PWD/../output:/output oer-template/docusaurus:latest
+```
+
+Finally, when wanting to view the content locally you will have to start a container by running the following command:
+
+The website will be available by accessing the `http://localhost:3000` address.
+
 ## Chapter Contents
 
 ### Lecture
@@ -65,13 +104,3 @@ Contributions are welcome.
 See the [contribution guide](CONTRIBUTING.md) on how you could report or fix issues and on how you can improve the content.
 
 Reviewers are requested to follow the [reviewing guide](REVIEWING.md).
-
-## Publishing workflow
-
-Before building the repository you have to setup the following items
-
-* select the GitHub Pages branch by following the [Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) tutorial; you will have to set up the `gh-pages` branch as the publishing branch;
-* add a publishing key named `ACCESS_TOKEN` by following the [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) tutorial.
-
-In order to publish the content of this repository, we use a github workflow located in the `.github/workflows/deployment.yml`.
-This workflow will build the site using docusaurus and publish the contents to a link similar to `<repository_name>.github.io`.

--- a/README.md
+++ b/README.md
@@ -50,9 +50,22 @@ In order to run the builder which will create the repository locally, you will h
 docker run -it -v $PWD/:/content -v $PWD/../output:/output <your-repo-name>/docusaurus:latest
 ```
 
-Finally, to view the content locally, you will have to start a container by running the following command:
+Finally, to view the content locally, you will have to start a container by running the following command in the `output` directory
 
-The website will be available by accessing the `http://localhost:3000` address.
+```
+python3 -m http.server
+```
+
+The website will be available by accessing the `http://localhost:8000` address. To change the defualt port you will add this a parameter to the above command as follows.
+
+```
+python3 -m http.server 8888
+```
+
+This command will open the web server on port `8888`.
+
+Make sure that you run command in the `output directory`.
+
 
 ## Chapter Contents
 

--- a/README.md
+++ b/README.md
@@ -15,28 +15,30 @@ Content for each chapter is split in two subfolders:
 Lecture content is expected to be presented and followed.
 Practice content is expected to be used hands-on individually or as part of team.
 
-## Publishing workflow
+## Publishing Workflow
 
 Before building the repository you have to set up the following items:
 
-* select the GitHub Pages branch by following the [Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) tutorial; you will have to set up the `gh-pages` branch as the publishing branch;
-* add a publishing key named `ACCESS_TOKEN` by following the [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) tutorial.
+* Select the GitHub Pages branch by following the [Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) tutorial.
+   You will have to set up the `gh-pages` branch as the publishing branch.
+* Add a publishing key named `ACCESS_TOKEN` by following the [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) tutorial.
 
-In order to publish the content of this repository, we use a GitHub workflow located in the `.github/workflows/deployment.yml`.
+In order to publish the content of this repository, we use a GitHub workflow located in `.github/workflows/deployment.yml`.
 This workflow will build the site using [Docusaurus](https://docusaurus.io/) and publish the contents to a link similar to `<github_username>.github.io`.
 
 ## Your first TODOs
 
 To configure this repo for the class for which you intend to develop content, you must make the following changes:
 
-* change the repository name to match your class name, the default is `oer-template`
-* in `config.yaml`:
-  * change `title` to you class name;
-  * change `url` to `<github_usename>.github.io`;
-  * change `baseurl` to `/` if the repository is the only one with a GitHub page in your profile, otherwise, change it to `<repository_name>`;
-  * change links to social media sites, if applicable.
+* Change the repository name to match your class name (the default name is `oer-template`).
+* In `config.yaml`:
+  * Change `title` to you class name.
+  * Change `url` to `<github_usename>.github.io`.
+  * Change `baseurl` to `/` if the repository is the only one with a GitHub page in your profile.
+     Otherwise, change it to `<repository_name>`.
+  * Change links to social media sites, if applicable.
 
-## Running locally
+## Running Locally
 
 When testing locally, you will have to build the container that will run the builder based on the `Dockerfile` defined in the repository root as follows:
 
@@ -50,7 +52,7 @@ In order to run the builder which will create the repository locally, you will h
 docker run -it -v $PWD/:/content -v $PWD/../output:/output <your-repo-name>/docusaurus:latest
 ```
 
-Finally, to view the content locally, you will have to start a container by running the following command in the `output` directory
+Finally, to view the content locally, you will have to start a container by running the following command in the `output/` directory:
 
 ```
 python3 -m http.server
@@ -65,7 +67,7 @@ python3 -m http.server 8888
 
 This command will open the web server on port `8888`.
 
-Make sure that you run command in the `output` directory.
+Make sure that you run command in the `output/` directory.
 
 
 ## Chapter Contents


### PR DESCRIPTION
Add more information in the README so people know where to start from when building the documentation for first time.